### PR TITLE
fix「字庫練習」的錯誤答案

### DIFF
--- a/composeExercise.html
+++ b/composeExercise.html
@@ -3285,7 +3285,7 @@
 鍛chje
 嘀rycb
 赭gcjka
-鋼capp
+鋼cbtu
 禎ifybc
 梯dcnh
 畢wtj
@@ -3870,7 +3870,7 @@
 寫jhxf
 橢dnlb
 漓eyub
-姬vsmm
+姬vsll
 庾ihxo
 霄mbfb
 戲yti


### PR DESCRIPTION
* 第 21 個字庫，「鋼」：「金日心心」，應爲「金月廿山」。「金日心心」爲「錕」。

* 第 25 個字庫，「姬」：「女尸一一」，應爲「女尸中中」。