### PR TITLE
fix: 合併 3 號與 4 號字庫，以使原 32 號字庫可使用。

### DIFF
--- a/composeExercise.html
+++ b/composeExercise.html
@@ -684,9 +684,6 @@
 氯onvne
 關anvit
 叫rvl
-</pre>
-
-<pre id="4">
 哂rmcw
 踵rmhjg
 樺dtmj
@@ -731,7 +728,7 @@
 段hjhne
 </pre>
 
-<pre id="5">
+<pre id="4">
 瀨edlc
 陽nlamh
 拙quu
@@ -884,7 +881,7 @@
 昔ta
 </pre>
 
-<pre id="6">
+<pre id="5">
 萵tbbr
 寐jvmd
 地gpd
@@ -1039,7 +1036,7 @@
 牢jhq
 </pre>
 
-<pre id="7">
+<pre id="6">
 咽rwk
 閣anher
 隙nlfhf
@@ -1192,7 +1189,7 @@
 忍sip
 </pre>
 
-<pre id="8">
+<pre id="7">
 巫moo
 耕qdtt
 考jkys
@@ -1345,7 +1342,7 @@
 磊mrmrr
 </pre>
 
-<pre id="9">
+<pre id="8">
 戳sgi
 鈉cob
 瑯mgiil
@@ -1499,7 +1496,7 @@
 描qtw
 </pre>
 
-<pre id="10">
+<pre id="9">
 餘oiomd
 砰mrmfj
 稚hdog
@@ -1651,7 +1648,7 @@
 昨ahs
 </pre>
 
-<pre id="11">
+<pre id="10">
 揩qppa
 滄eoir
 錦chab
@@ -1804,7 +1801,7 @@
 糢fdtak
 </pre>
 
-<pre id="12">
+<pre id="11">
 緊sevif
 苟tpr
 軾jjipm
@@ -1957,7 +1954,7 @@
 微houuk
 </pre>
 
-<pre id="13">
+<pre id="12">
 移hdnin
 戮shi
 髮shikk
@@ -2110,7 +2107,7 @@
 念oinp
 </pre>
 
-<pre id="14">
+<pre id="13">
 灤evfd
 甌srmvn
 蟀liyij
@@ -2263,7 +2260,7 @@
 稀hdkkb
 </pre>
 
-<pre id="15">
+<pre id="14">
 冗bhn
 遴yfdq
 風hnhli
@@ -2416,7 +2413,7 @@
 慣pwjc
 </pre>
 
-<pre id="16">
+<pre id="15">
 壤gyrv
 鐳cmbw
 崖umgg
@@ -2569,7 +2566,7 @@
 櫓dnwa
 </pre>
 
-<pre id="17">
+<pre id="16">
 颱hnir
 卵hhsli
 喝rapv
@@ -2722,7 +2719,7 @@
 瘤khhw
 </pre>
 
-<pre id="18">
+<pre id="17">
 踫rmttc
 瀟etlx
 臺grbg
@@ -2875,7 +2872,7 @@
 賣gwlc
 </pre>
 
-<pre id="19">
+<pre id="18">
 恨pav
 扯qylm
 雉okog
@@ -3028,7 +3025,7 @@
 槳vid
 </pre>
 
-<pre id="20">
+<pre id="19">
 循hohju
 稍hdfb
 迥ybr
@@ -3181,7 +3178,7 @@
 忌sup
 </pre>
 
-<pre id="21">
+<pre id="20">
 審jhdw
 釋hdwlj
 止ylm
@@ -3334,7 +3331,7 @@
 抨qmfj
 </pre>
 
-<pre id="22">
+<pre id="21">
 進yog
 堪gtmv
 糕fdtgf
@@ -3487,7 +3484,7 @@
 厲mtwb
 </pre>
 
-<pre id="23">
+<pre id="22">
 忙pyv
 莎tefh
 躪rmtag
@@ -3640,7 +3637,7 @@
 蠻vflmi
 </pre>
 
-<pre id="24">
+<pre id="23">
 箋hii
 鷥vfhaf
 抓qhlo
@@ -3793,7 +3790,7 @@
 熟yif
 </pre>
 
-<pre id="25">
+<pre id="24">
 夥wdnin
 登nomrt
 廷nkhg
@@ -3946,7 +3943,7 @@
 羸yrbtn
 </pre>
 
-<pre id="26">
+<pre id="25">
 燧fyto
 柄dmob
 渺ebuh
@@ -4099,7 +4096,7 @@
 芥toll
 </pre>
 
-<pre id="27">
+<pre id="26">
 懸bfp
 暑ajka
 躲hhhnd
@@ -4252,7 +4249,7 @@
 被ldhe
 </pre>
 
-<pre id="28">
+<pre id="27">
 紐vfng
 桅dnmu
 請yrqmb
@@ -4405,7 +4402,7 @@
 籟hdlc
 </pre>
 
-<pre id="29">
+<pre id="28">
 桶dnib
 閉andh
 債oqmc
@@ -4558,7 +4555,7 @@
 雨mlby
 </pre>
 
-<pre id="30">
+<pre id="29">
 落tehr
 述yijc
 贊hubuc
@@ -4711,7 +4708,7 @@
 說yrcru
 </pre>
 
-<pre id="31">
+<pre id="30">
 辭bbytj
 號rsypu
 憚prrj
@@ -4863,7 +4860,7 @@
 踴rmnbs
 </pre>
 
-<pre id="32">
+<pre id="31">
 倨osjr
 激ehsk
 氟onlln


### PR DESCRIPTION
　　瀏覽源始碼時發現實際上定義了 33 個字庫，而且 33 個字庫合計才是 4800 個漢字。

　　統計各字庫漢字數量後，發現 3 號與 4 號字庫合併後，漢字數量的分配將更爲平均，而且可解決無法使用原 32 號字庫的問題。已確認 3 號與 4 號字庫間沒有倉頡碼重複的漢字。

舊字庫號 | 0–2 |   3 |  4 |   5 |   6 | 7, 8 |   9 |  10 | 11–30 | 31, 32
 --------- | --- | --- |----| --- | --- | --- | --- | --- | ----- | -----
漢字數量 | 150 | 108 | 42 | 150 | 152 | 150 | 151 | 149 |   150 |   149
新字庫號 | 0–2 |   3 |    |   4 |   5 | 6, 7 |   8 |   9 | 10–29 | 30, 31
漢字數量 | 150 | 150 |    | 150 | 152 | 150 | 151 | 149 |   150 |   149

　　此外，發現了未使用的完成所有字庫的訊息。先前的解決方案將其重新啟用並修正統計上的不合，但目前已取消。