### PR TITLE
fix(*.html): og:discription -> og:description: fix SEO tag typo

### DIFF
--- a/cangJieNewStar.html
+++ b/cangJieNewStar.html
@@ -11,7 +11,7 @@
 <!-- 後設資料 -->
 <meta name="date" content="2016-08-31">
 <meta name="keywords" property="og:article:tag" content="倉頡新星, 教學, 倉頡輸入法, 練習, 流程, 使用說明">
-<meta property="og:discription" name="discription" content="如何使用本軟體倉頡新星學習倉頡輸入法。">
+<meta property="og:description" name="description" content="如何使用本軟體倉頡新星學習倉頡輸入法。">
 <link rel="prev" type="text/html" href="why.html">
 <link rel="next" type="text/html" href="compose.html">
 <link rel="index" type="text/html" href="index.html">

--- a/character.html
+++ b/character.html
@@ -11,7 +11,7 @@
 <!-- 後設資料 -->
 <meta name="date" content="2016-08-29">
 <meta name="keywords" property="og:article:tag" content="倉頡新星, 教學, 倉頡輸入法, 字根, 字首, 取碼, 拆字, 練習">
-<meta property="og:discription" name="discription" content="倉頡拆字取碼原理。">
+<meta property="og:description" name="description" content="倉頡拆字取碼原理。">
 <link rel="prev" type="text/html" href="cangjie.html">
 <link rel="next" type="text/html" href="character.html">
 <link rel="index" type="text/html" href="index.html">

--- a/compose.html
+++ b/compose.html
@@ -11,7 +11,7 @@
 <!-- 後設資料 -->
 <meta name="date" content="2016-08-29">
 <meta name="keywords" property="og:article:tag" content="倉頡新星, 教學, 倉頡輸入法, 字根, 字首, 取碼, 拆字, 練習">
-<meta property="og:discription" name="discription" content="倉頡拆字取碼原理。">
+<meta property="og:description" name="description" content="倉頡拆字取碼原理。">
 <link rel="prev" type="text/html" href="cangJieNewStar.html">
 <link rel="next" type="text/html" href="key.html">
 <link rel="index" type="text/html" href="index.html">

--- a/composeExercise.html
+++ b/composeExercise.html
@@ -12,7 +12,7 @@
 <!-- 後設資料 -->
 <meta name="date" content="2016-08-25">
 <meta name="keywords" property="og:article:tag" content="倉頡新星, 倉頡輸入法, cj, 練習, 教學, 拆字">
-<meta property="og:discription" name="discription" content="用 HTML + CSS + JS 做的倉頡輸入法拆字練習軟體。">
+<meta property="og:description" name="description" content="用 HTML + CSS + JS 做的倉頡輸入法拆字練習軟體。">
 
 <!-- 和網頁位置有關 -->
 <meta property="og:url" content="http://gholk.github.io/cjns/exercise.html">

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 <!-- 後設資料 -->
 <meta name="date" content="2016-08-29">
 <meta name="keywords" property="og:article:tag" content="倉頡新星, 教學, 倉頡輸入法, javascript, 練習">
-<meta property="og:discription" name="discription" content="倉頡輸入法教學軟體倉頡新星的介紹。">
+<meta property="og:description" name="description" content="倉頡輸入法教學軟體倉頡新星的介紹。">
 <link rel="next" type="text/html" href="why.html">
 
 <!-- 和網頁位置有關 -->

--- a/key.html
+++ b/key.html
@@ -11,7 +11,7 @@
 <!-- 後設資料 -->
 <meta name="date" content="2016-08-29">
 <meta name="keywords" property="og:article:tag" content="倉頡新星, 教學, 練習, 盲打, 背鍵位">
-<meta property="og:discription" name="discription" content="背鍵位的方法與好處。">
+<meta property="og:description" name="description" content="背鍵位的方法與好處。">
 <link rel="prev" type="text/html" href="cangjie.html">
 <link rel="next" type="text/html" href="keyExercise.html">
 <link rel="index" type="text/html" href="index.html">

--- a/keyExercise.html
+++ b/keyExercise.html
@@ -11,7 +11,7 @@
 <!-- 後設資料 -->
 <meta name="date" content="2016-08-30">
 <meta name="keywords" property="og:article:tag" content="鍵位, 字根, 倉頡新星, 教學, 倉頡輸入法, javascript, 練習">
-<meta property="og:discription" name="discription" content="倉頡新星背鍵位、字根練習。">
+<meta property="og:description" name="description" content="倉頡新星背鍵位、字根練習。">
 <link rel="prev" type="text/html" href="why.html">
 <link rel="next" type="text/html" href="composeExercise.html">
 

--- a/why.html
+++ b/why.html
@@ -11,7 +11,7 @@
 <!-- 後設資料 -->
 <meta name="date" content="2016-08-29">
 <meta name="keywords" property="og:article:tag" content="倉頡新星, 倉頡輸入法, 比較">
-<meta property="og:discription" name="discription" content="用倉頡的是因為其它輸入法都不太行。">
+<meta property="og:description" name="description" content="用倉頡的是因為其它輸入法都不太行。">
 <link rel="next" type="text/html" href="cangJieNewStar.html">
 <link rel="index" type="text/html" href="index.html">
 


### PR DESCRIPTION
　　原本的網站說明後設資料的屬性値有錯誤拼寫，因此未能如期運作。已在此修正。